### PR TITLE
Fix boot issues with RPi

### DIFF
--- a/l4/pkg/bootstrap/server/src/platform_common.cc
+++ b/l4/pkg/bootstrap/server/src/platform_common.cc
@@ -44,6 +44,9 @@ scan_ram_size(unsigned long base_addr, unsigned long max_scan_size_mb)
        offset *= 2)
     *(unsigned long *)(base_addr + offset) = 0;
 
+  // avoid gcc/clang optimization figuring out that base_addr might
+  // always be 0 and generating a trap here
+  asm("" : "+r" (base_addr));
   // write something at offset 0, does it appear elsewhere?
   *(unsigned long *)base_addr = 0x12345678;
   asm volatile("" : : : "memory");


### PR DESCRIPTION
This fix allows foc r67 to successfully boot on the RPi Model B.
Changes are taken from https://github.com/skalk/foc/blob/r72/l4/pkg/bootstrap/server/src/platform_common.cc#L47-L49

@BugUser0815 Please check if this doesn't interfere with the boot process of the Pandaboard