### PR TITLE
WIP: Change uart_nr for exynos platforms

### DIFF
--- a/l4/pkg/bootstrap/server/src/platform/exynos.cc
+++ b/l4/pkg/bootstrap/server/src/platform/exynos.cc
@@ -30,7 +30,7 @@ public:
     static L4::Uart_s5pv210 _uart;
     const unsigned long uart_offset = 0x10000;
     unsigned long uart_base;
-    unsigned uart_nr = 2;
+    unsigned uart_nr = 1;
 
 #ifdef PLATFORM_TYPE_exynos4
     uart_base = 0x13800000;


### PR DESCRIPTION
For the support of the odroid u3 platform we need to change the uart_nr from 2 to 1 for exynos paltforms to get some output from the kernel.