### PR TITLE
Hardcode ram of rv platforms to 2x512MB

### DIFF
--- a/l4/pkg/bootstrap/server/src/platform/rv.cc
+++ b/l4/pkg/bootstrap/server/src/platform/rv.cc
@@ -24,6 +24,17 @@ namespace {
 class Platform_arm_rv : public Platform_single_region_ram
 {
   bool probe() { return true; }
+
+  /* enfore two memory regions */
+  void setup_memory_map()
+  {
+    Region_list *ram = mem_manager->ram;
+    Region_list *regions = mem_manager->regions;
+    /* 2x512 MB */
+    ram->add(Region::n(0x20000000, 0x40000000, ".ram", Region::Ram));
+    ram->add(Region::n(0x70000000, 0x90000000, ".ram", Region::Ram));
+  }
+
   void init()
   {
     static L4::Io_register_block_mmio r(0x10009000);


### PR DESCRIPTION
This makes a total of 1024MB RAM available for the pbxa9 platform.

jfr. 
- http://infocenter.arm.com/help/topic/com.arm.doc.dui0440b/Bbajihec.html
- https://os.inf.tu-dresden.de/pipermail/l4-hackers/2011/005137.html

needs https://github.com/argos-research/genode/pull/29, otherweise qemu doesn't boot anymore.